### PR TITLE
The most recently release mod version is not always the best one

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sptModTracker",
   "appId": "spt.mod.tracker",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "spt mod tracker",
   "author": "HioP <hiopvkashu@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
It was previously assumed that the most recently published version of a mod is the most compatible with the current game version, now all available versions are checked for the best one.
Some mods also currently have a spt version of ~4 resulting in an undefined minor value causing an output of warning instead of success (ie wrong color)
Version to 1.0.10

